### PR TITLE
Allow more recent node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "dependencies": {}
   , "main": "index"
-  , "engines": { "node": "0.4.x" }
+  , "engines": { "node": ">=0.4.0" }
 }


### PR DESCRIPTION
The current package.json specifies only node 0.4.x. I've tested the example code in both node 0.5.6 and node 0.6.1 and it seems to work just fine.
