### PR TITLE
tick(0) should not be the same as tick()

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -67,7 +67,8 @@ function ProgressBar(fmt, options) {
  */
 
 ProgressBar.prototype.tick = function(len, tokens){
-  len = len || 1;
+  if (len !== 0)
+    len = len || 1;
 
   // swap tokens
   if ('object' == typeof len) tokens = len, len = 1;


### PR DESCRIPTION
I noticed that progress bars are shown on the first tick. The problem is that e.g. for a db migration script which i'm now creating, the db commands are sent, than there is a huge (like 10 seconds) pause, and after that pause, the progress is finally shown. I wanted the progress bar to be shown immediately, even if it shows 0%. However, when I tried `tick(0)`, it was considered as `tick()`, which I think is wrong.

It's very easy to fix, please see the commit attached.

Thank you for a great library, btw!
