### PR TITLE
Fixed logic bug that caused bar to jump one extra space at the end

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -84,12 +84,12 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   var percent = this.curr / this.total * 100
     , complete = Math.round(this.width * (this.curr / this.total))
-    , incomplete = this.width - complete
+    , incomplete
     , elapsed = new Date - this.start
     , eta = elapsed * (this.total / this.curr - 1)
 
   complete = Array(complete).join(this.chars.complete);
-  incomplete = Array(incomplete).join(this.chars.incomplete);
+  incomplete = Array(this.width - complete.length).join(this.chars.incomplete);
 
   var str = this.fmt
     .replace(':bar', complete + incomplete)


### PR DESCRIPTION
I noticed while using this in one of my tools that the progress bar would be a static size until the very end and then it would jump out 1-2 characters.

This patch allows the bar to stay the same size and looks better ;)

You can test it by running your first example from the readme and hitting enter a few times to get the old ones above it. You can see at the very end, the bar jumps out.
