### PR TITLE
On OSX revert back to terminal hack to avoid a readline bug

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -47,6 +47,13 @@ function ProgressBar(fmt, options) {
     output: options.stream || process.stdout
   });
   this.rl.setPrompt('', 0);
+  this.rl.clearLine = function() {
+      if (process.platform === 'darwin') {
+        this.output.write('\r');
+      } else {
+        this.write(null, {ctrl: true, name: 'u'});
+      }
+  };
 
   options = options || {};
   if ('string' != typeof fmt) throw new Error('format required');
@@ -83,7 +90,7 @@ ProgressBar.prototype.tick = function(len, tokens){
   // progress complete
   if ((this.curr += len) > this.total) {
     this.complete = true;
-    //this.rl.write(null, {ctrl: true, name: 'u'});
+    this.rl.clearLine();
     this.rl.resume();
     this.rl.close();
     return;
@@ -110,7 +117,7 @@ ProgressBar.prototype.tick = function(len, tokens){
       str = str.replace(':' + key, tokens[key]);
     }
   }
-
-  this.rl.write(null, {ctrl: true, name: 'u'});
+  
+  this.rl.clearLine();
   this.rl.write(str);
 };


### PR DESCRIPTION
Ran into an issue with one of my apps, I believe it's a readline/process issue, but this reverts the `ctrl+u` clearing back to `\r` only for OSX.

This still works on Windows and everywhere else, but this fixes an issue when you have several child processes sharing the same stdin, the `ctrl+u` actually looks to be getting called once per child that's bound and not just once. So the progress bar will write one line and delete 10 (one per child) before it..

Totally screwy and will take a ton of debugging, but this works for now.
