### PR TITLE
Added option to force stream to be treated like a TTY.

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -26,6 +26,7 @@ exports.version = '0.1.0';
  *   - `stream` the output stream defaulting to stdout
  *   - `complete` completion character defaulting to "="
  *   - `incomplete` incomplete character defaulting to "-"
+ *   - `terminal` whether streams should be treated like a TTY defaulting to checking `isTTY` on `stream`
  *
  * Tokens:
  *
@@ -42,9 +43,11 @@ exports.version = '0.1.0';
  */
 
 function ProgressBar(fmt, options) {
+  options = options || {};
   this.rl = require('readline').createInterface({
     input: process.stdin,
-    output: options.stream || process.stdout
+    output: options.stream || process.stdout,
+    terminal: options.terminal
   });
   this.rl.setPrompt('', 0);
   this.rl.clearLine = function() {
@@ -55,7 +58,6 @@ function ProgressBar(fmt, options) {
       }
   };
 
-  options = options || {};
   if ('string' != typeof fmt) throw new Error('format required');
   if ('number' != typeof options.total) throw new Error('total required');
   this.fmt = fmt;


### PR DESCRIPTION
Currently, if one uses `child_process.spawn` to launch a script that uses `ProgressBar`, it will throw an exception or will not output to the terminal (on OSX). This patch adds an option to force readline to treat the stream it is given as a TTY. This prevents the exception and reenables output.
