### PR TITLE
Avoid blinking: do not refresh progress bar if percent hasn't changed.

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -62,6 +62,7 @@ function ProgressBar(fmt, options) {
   this.curr = 0;
   this.total = options.total;
   this.width = options.width || this.total;
+  this.percent = 0;
   this.chars = {
       complete: options.complete || '='
     , incomplete: options.incomplete || '-'
@@ -96,11 +97,18 @@ ProgressBar.prototype.tick = function(len, tokens){
     return;
   }
 
-  var percent = this.curr / this.total * 100
+  var percent = Math.round(this.curr / this.total * 100)
     , complete = Math.round(this.width * (this.curr / this.total))
     , incomplete
     , elapsed = new Date - this.start
     , eta = elapsed * (this.total / this.curr - 1)
+
+  // do not update progress bar, when not neccessary (avoids blinking)     
+  if (percent <= this.percent) {
+    return;
+  }
+  this.percent = percent;
+
   complete = Array(complete).join(this.chars.complete);
   incomplete = Array(this.width - complete.length).join(this.chars.incomplete);
 


### PR DESCRIPTION
When refreshed too often, progress starts to blink, while no useful info is reported. 
