### PR TITLE
added :etaFormat format option, format eta with hh:mm:ss

### DIFF
--- a/examples/formats.js
+++ b/examples/formats.js
@@ -65,7 +65,7 @@ function bar4() {
 }
 
 function bar5() {
-  var bar = new ProgressBar('  [:bar] :elapseds elapsed, eta :etas', {
+  var bar = new ProgressBar('  [:bar] :elapseds elapsed, eta :etas etaFormat :etaFormat', {
       width: 8
     , total: 50
   });

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -103,6 +103,7 @@ ProgressBar.prototype.tick = function(len, tokens){
     .replace(':current', this.curr)
     .replace(':total', this.total)
     .replace(':elapsed', (elapsed / 1000).toFixed(1))
+    .replace(':etaFormat', etaFormat(eta))
     .replace(':eta', (eta / 1000).toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%');
 
@@ -114,4 +115,17 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   this.rl.clearLine();
   this.rl.write(str);
+};
+
+function etaFormat(eta) {
+    var totalSec = eta / 1000;
+    var hours = parseInt(totalSec / 3600) % 24;
+    var minutes = parseInt(totalSec / 60) % 60;
+    var seconds = totalSec % 60;
+
+    if (hours > 0)
+        return (hours < 10 ? "0" + hours : hours) + "h" + (minutes < 10 ? "0" + minutes.toFixed(0) : minutes.toFixed(0)) + "m" + (seconds  < 10 ? "0" + seconds.toFixed(0) : seconds.toFixed(0))  + "s";
+    if (minutes > 0)
+        return (minutes < 10 ? "0" + minutes.toFixed(0) : minutes.toFixed(0)) + "m" + (seconds  < 10 ? "0" + seconds.toFixed(0) : seconds.toFixed(0))  + "s";
+    return (seconds  < 10 ? "0" + seconds.toFixed(0) : seconds.toFixed(0))  + "s";
 };


### PR DESCRIPTION
I have some very long operations and wanted a more easy way to know the eta.
the new :etaFormat option write the eta time with the format -> hh:mm:ss

Very simple but useful ;).
