### PR TITLE
OSX will happily do the same line-clear trick

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -42,11 +42,7 @@ function ProgressBar(fmt, options) {
   });
   this.rl.setPrompt('', 0);
   this.rl.clearLine = function() {
-      if (process.platform === 'darwin') {
-        this.output.write('\r');
-      } else {
-        this.write(null, {ctrl: true, name: 'u'});
-      }
+    this.write(null, {ctrl: true, name: 'u'});
   };
 
   options = options || {};


### PR DESCRIPTION
The "darwin" platform is too wide to determine terminal capabilities: OSX 10.8 does the line-clear-trick just fine.

If this code has to target older versions of OSX, a check that does not involve `process.platform` should be used, but in the mean time I can strongly recommend merging this in to make progress bars beautiful on OSX =)
