### PR TITLE
Extract render method

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -103,8 +103,8 @@ ProgressBar.prototype.render = function(tokens){
     .replace(':bar', complete + incomplete)
     .replace(':current', this.curr)
     .replace(':total', this.total)
-    .replace(':elapsed', isNaN(elapsed) ? "?.?" : (elapsed / 1000).toFixed(1))
-    .replace(':eta', isNaN(eta) ? "?.?" : (eta / 1000).toFixed(1))
+    .replace(':elapsed', isNaN(elapsed) ? "0.0" : (elapsed / 1000).toFixed(1))
+    .replace(':eta', isNaN(eta) ? "0.0" : (eta / 1000).toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%');
 
   if (tokens) {


### PR DESCRIPTION
Extract render method to enable rendering before any tick happens.

In situations where first tick is slow to get fired, nothing is displayed, extracting render logic to his own method enable developers to force display the progress bar right away, example code:

``` javascript
var ProgressBar = require('progress');

var bar = new ProgressBar('downloading [:bar] :percent :etas :current :total :elapsed', { total: 50, width: 10 });
bar.render();
var timer = setInterval(function(){
  bar.tick();
  if (bar.complete) {
    console.log('\ncomplete\n');
    clearInterval(timer);
  }
}, 2000);
```
