### PR TITLE
Render fails if STDOUT is not a TTY.

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -102,6 +102,10 @@ ProgressBar.prototype.tick = function(len, tokens){
  */
 
 ProgressBar.prototype.render = function(tokens){
+  if(!process.stdout.isTTY) {
+    return;
+  }
+
   var percent = (this.curr >= this.total) ? 100 : this.curr / this.total * 100
     , complete = Math.round(this.width * (this.curr / this.total))
     , incomplete


### PR DESCRIPTION
We ran into an issue on our Jenkins server when trying to npm install. One of our dependencies uses a progress bar during its installation process, and when installing on the non-interactive shell that Jenkins provides, we ran into the following error:

```
string_decoder.js:129
  var i = (buffer.length >= 3) ? 3 : buffer.length;
                 ^
TypeError: Cannot read property 'length' of null
    at StringDecoder.detectIncompleteChar (string_decoder.js:129:18)
    at StringDecoder.write (string_decoder.js:99:28)
    at Interface._normalWrite (readline.js:303:30)
    at Interface.write (readline.js:294:49)
    at Interface.ProgressBar.rl.clearLine (/mnt/jenkins/workspace/LessonPlayer-review/node_modules/grunt-contrib-imagemin/node_modules/gifsicle/node_modules/bin-wrapper/node_modules/progress/lib/node-progress.js:46:10)
    at ProgressBar.render (/mnt/jenkins/workspace/LessonPlayer-review/node_modules/grunt-contrib-imagemin/node_modules/gifsicle/node_modules/bin-wrapper/node_modules/progress/lib/node-progress.js:124:11)
    at ProgressBar.tick (/mnt/jenkins/workspace/LessonPlayer-review/node_modules/grunt-contrib-imagemin/node_modules/gifsicle/node_modules/bin-wrapper/node_modules/progress/lib/node-progress.js:83:8)
```

So, I added a small guard to the `render` function to skip rendering if STDOUT is not a TTY. This resolved our issue.

Thanks in advance!
