### PR TITLE
Support progress on stderr while piping stdout

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,7 @@ var timer = setInterval(function(){
   - `complete` completion character defaulting to "="
   - `incomplete` incomplete character defaulting to "-"
   - `clear` option to clear the bar on completion defaulting to false
+  - `quiet` disables the progress bar defaulting to false unless stream isn't tty
   - `callback` optional function to call when the progress bar completes
 
 ## Tokens:

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -21,6 +21,7 @@ exports = module.exports = ProgressBar;
  *   - `stream` the output stream defaulting to stdout
  *   - `complete` completion character defaulting to "="
  *   - `incomplete` incomplete character defaulting to "-"
+ *   - `quiet` disables the progress bar defaulting to false unless stream isn't tty
  *   - `callback` optional function to call when the progress bar completes
  *
  * Tokens:
@@ -38,9 +39,10 @@ exports = module.exports = ProgressBar;
  */
 
 function ProgressBar(fmt, options) {
+  var outputStream = options.stream || progress.stdout;
   this.rl = require('readline').createInterface({
     input: process.stdin,
-    output: options.stream || process.stdout
+    output: outputStream
   });
   this.rl.setPrompt('', 0);
   this.rl.clearLine = function() {
@@ -66,6 +68,7 @@ function ProgressBar(fmt, options) {
       complete: options.complete || '='
     , incomplete: options.incomplete || '-'
   };
+  this.quiet = 'quiet' in options ? options.quiet : !outputStream.isTTY;
   this.callback = options.callback || function () {};
 }
 
@@ -109,7 +112,7 @@ ProgressBar.prototype.tick = function(len, tokens){
  */
 
 ProgressBar.prototype.render = function(tokens){
-  if(!process.stdout.isTTY) {
+  if (this.quiet) {
     return;
   }
 


### PR DESCRIPTION
Render has a guard clause for process.stdout.isTTY, which makes it impossible to pipe stdout while rendering progress bar on stderr. This PR makes the progress bar quiet based on the TTY of the configured output stream.

It also adds a quiet option to override the behaviour. This also allows for easy integration in scripts which have its own quiet flag.

The progress bar will be quiet by default if configured with a WriteStream which doesn't support TTY. If that's a real use case then it can always be fixed with a "quiet: false".

On another note, the output stream should IMHO default to stderr instead of stdout, like curl. But it's simple enough for the developer to switch.
