### PR TITLE
Prevent throwing an error when skipping too far.

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -119,6 +119,7 @@ ProgressBar.prototype.render = function(tokens){
     , elapsed = new Date - this.start
     , eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);
 
+  complete = Math.min(Math.max(0, complete), this.width);
   complete = Array(complete).join(this.chars.complete);
   incomplete = Array(this.width - complete.length).join(this.chars.incomplete);
 


### PR DESCRIPTION
If `bar.curr` is far enough past `bar.total`, `complete` could be larger than `bar.width`. This would cause the `incomplete` character count to be below 0.

Because negative numbers aren't valid array lengths, this would throw an error in specific circumstances: small values for `bar.total`, and larger values being passed to `bar.tick()`.
