### PR TITLE
Increase performance and reduce blinking

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -67,6 +67,7 @@ function ProgressBar(fmt, options) {
     , incomplete: options.incomplete || '-'
   };
   this.callback = options.callback || function () {};
+  this.currentLine = '';
 }
 
 /**
@@ -138,9 +139,11 @@ ProgressBar.prototype.render = function(tokens){
       str = str.replace(':' + key, tokens[key]);
     }
   }
-
-  this.rl.clearLine();
-  this.rl.write(str);
+  if(this.currentLine !== str) {
+    this.rl.clearLine();
+    this.rl.write(str);
+  }
+  this.currentLine = str;
 };
 
 /**


### PR DESCRIPTION
remember the last written line to prevent writing the same line again. 
This decreased the run time of my database migration script by ~20 seconds (55s vs 34s). 
Lots of data, fast databases, slow terminal. 
This change shouldn't have much visual effect (besides some reduced blinking) and should increase the performance in cases where a lot of ticks appear. 
