### PR TITLE
Prevent the progress bar from exceeding the TTY width

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### 1.1.6 / 2014-06-16
+
+ * now prevents progress bar from exceeding TTY width by limiting its width to
+   the with of the TTY
+
 ### 1.1.5 / 2014-03-25
 
  * updated documentation and various other repo maintenance

--- a/examples/toolong.js
+++ b/examples/toolong.js
@@ -1,0 +1,23 @@
+/**
+ * An example to show how node-progress handles user-specified widths
+ * which exceed the number of columns in the terminal
+ */
+
+var ProgressBar = require('../');
+
+// simulated download, passing the chunk lengths to tick()
+
+var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+    complete: '='
+  , incomplete: ' '
+  , width: 1024     /* something longer than the terminal width */
+  , total: 100
+});
+
+(function next() {
+  bar.tick(1);
+
+  if (!bar.complete) {
+    setTimeout(next, 10);
+  }
+})();

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -109,16 +109,12 @@ ProgressBar.prototype.render = function (tokens) {
   ratio = Math.min(Math.max(ratio, 0), 1);
 
   var percent = ratio * 100;
-  var complete = Math.round(this.width * ratio);
   var incomplete;
   var elapsed = new Date - this.start;
   var eta = (percent == 100) ? 0 : elapsed * (this.total / this.curr - 1);
 
-  complete = Array(complete).join(this.chars.complete);
-  incomplete = Array(this.width - complete.length).join(this.chars.incomplete);
-
+  /* populate the bar template with percentages and timestamps */
   var str = this.fmt
-    .replace(':bar', complete + incomplete)
     .replace(':current', this.curr)
     .replace(':total', this.total)
     .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
@@ -126,6 +122,18 @@ ProgressBar.prototype.render = function (tokens) {
       .toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%');
 
+  /* compute the available space for the bar */
+  var availableSpace = this.stream.columns - str.replace(':bar', '').length;
+  var width = Math.min(this.width, availableSpace);
+
+  /* TODO: the following assumes the user has one ':bar' token */
+  complete = Array(Math.round(width * ratio)).join(this.chars.complete);
+  incomplete = Array(width - complete.length).join(this.chars.incomplete);
+
+  /* fill in the actual progress bar */
+  str = str.replace(':bar', complete + incomplete);
+
+  /* replace the extra tokens */
   if (tokens) for (var key in tokens) str = str.replace(':' + key, tokens[key]);
 
   if (this.lastDraw !== str) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "progress"
-  , "version": "1.1.5"
+  , "version": "1.1.6"
   , "description": "Flexible ascii progress bar"
   , "keywords": ["cli", "progress"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"


### PR DESCRIPTION
Hi @hallas,

Here's a fix for #60 (and, consequently, #64). I've changed it so that the "available space" for the actual progress bar is computed - which is determined by populating percentages, timestamps, etc. into the template - and calculates what room is left for the "complete" and "incomplete" portions. After which it sets the widths of these portions appropriately.

This change will not affect existing bars, only ones which specify too large of a width.

I've included an example as well, using a width of 1024.
