### PR TITLE
Ensure that the available bar space is never negative - fixes #68

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -122,8 +122,8 @@ ProgressBar.prototype.render = function (tokens) {
       .toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%');
 
-  /* compute the available space for the bar */
-  var availableSpace = this.stream.columns - str.replace(':bar', '').length;
+  /* compute the available space (non-zero) for the bar */
+  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
   var width = Math.min(this.width, availableSpace);
 
   /* TODO: the following assumes the user has one ':bar' token */


### PR DESCRIPTION
Hey @hallas,

Just a quick change to make sure width never goes below 0. Technically we can never have negative available space.
