### PR TITLE
Use `this.stream` instead of `console.log` when terminating a progress bar

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -176,5 +176,5 @@ ProgressBar.prototype.terminate = function () {
   if (this.clear) {
     this.stream.clearLine();
     this.stream.cursorTo(0);
-  } else console.log();
+  } else this.stream.write('\n');
 };


### PR DESCRIPTION
I noticed in one of my projects, while running unit tests where I've stubbed out `process.stdout`, that `node-progress` is writing out a newline after using it even when a stream is provided to the constructor. This is because `console.log` is being used during the termination rather than `this.stream.write`.

This PR effectively does the same thing.