### PR TITLE
Avoid rapidly rendering updates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `stream` the output stream defaulting to stderr
 - `complete` completion character defaulting to "="
 - `incomplete` incomplete character defaulting to "-"
+- `renderDelay` minimum time between updates in milliseconds defaulting to 50
 - `clear` option to clear the bar on completion defaulting to false
 - `callback` optional function to call when the progress bar completes
 

--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `stream` the output stream defaulting to stderr
 - `complete` completion character defaulting to "="
 - `incomplete` incomplete character defaulting to "-"
-- `renderThrottle` minimum time between updates in milliseconds defaulting to 50
+- `renderThrottle` minimum time between updates in milliseconds defaulting to 16
 - `clear` option to clear the bar on completion defaulting to false
 - `callback` optional function to call when the progress bar completes
 

--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `stream` the output stream defaulting to stderr
 - `complete` completion character defaulting to "="
 - `incomplete` incomplete character defaulting to "-"
-- `renderDelay` minimum time between updates in milliseconds defaulting to 50
+- `renderThrottle` minimum time between updates in milliseconds defaulting to 50
 - `clear` option to clear the bar on completion defaulting to false
 - `callback` optional function to call when the progress bar completes
 

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -60,7 +60,7 @@ function ProgressBar(fmt, options) {
     complete   : options.complete || '=',
     incomplete : options.incomplete || '-'
   };
-  this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 50) : 0;
+  this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 16) : 0;
   this.callback = options.callback || function () {};
   this.tickTokens = {};
   this.lastDraw = '';

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -60,6 +60,7 @@ function ProgressBar(fmt, options) {
     complete   : options.complete || '=',
     incomplete : options.incomplete || '-'
   };
+  this.renderDelay = options.renderDelay === undefined ? 50 : options.renderDelay;
   this.callback = options.callback || function () {};
   this.lastDraw = '';
 }
@@ -83,10 +84,15 @@ ProgressBar.prototype.tick = function(len, tokens){
   if (0 == this.curr) this.start = new Date;
 
   this.curr += len
-  this.render(tokens);
+
+  // schedule render
+  if (!this.renderTimeout) {
+    this.renderTimeout = setTimeout(this.render.bind(this), this.renderDelay, tokens);
+  }
 
   // progress complete
   if (this.curr >= this.total) {
+    if (this.renderTimeout) this.render(tokens);
     this.complete = true;
     this.terminate();
     this.callback(this);
@@ -103,6 +109,8 @@ ProgressBar.prototype.tick = function(len, tokens){
  */
 
 ProgressBar.prototype.render = function (tokens) {
+  clearTimeout(this.renderTimeout);
+  this.renderTimeout = null;
   if (!this.stream.isTTY) return;
 
   var ratio = this.curr / this.total;

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -62,6 +62,7 @@ function ProgressBar(fmt, options) {
   };
   this.renderDelay = options.renderDelay === undefined ? 50 : options.renderDelay;
   this.callback = options.callback || function () {};
+  this.tickTokens = {};
   this.lastDraw = '';
 }
 
@@ -79,6 +80,7 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   // swap tokens
   if ('object' == typeof len) tokens = len, len = 1;
+  if (tokens) this.tickTokens = tokens;
 
   // start time for eta
   if (0 == this.curr) this.start = new Date;
@@ -87,12 +89,12 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   // schedule render
   if (!this.renderTimeout) {
-    this.renderTimeout = setTimeout(this.render.bind(this), this.renderDelay, tokens);
+    this.renderTimeout = setTimeout(this.render.bind(this), this.renderDelay);
   }
 
   // progress complete
   if (this.curr >= this.total) {
-    if (this.renderTimeout) this.render(tokens);
+    if (this.renderTimeout) this.render();
     this.complete = true;
     this.terminate();
     this.callback(this);
@@ -111,6 +113,9 @@ ProgressBar.prototype.tick = function(len, tokens){
 ProgressBar.prototype.render = function (tokens) {
   clearTimeout(this.renderTimeout);
   this.renderTimeout = null;
+
+  if (tokens) this.tickTokens = tokens;
+
   if (!this.stream.isTTY) return;
 
   var ratio = this.curr / this.total;
@@ -143,7 +148,7 @@ ProgressBar.prototype.render = function (tokens) {
   str = str.replace(':bar', complete + incomplete);
 
   /* replace the extra tokens */
-  if (tokens) for (var key in tokens) str = str.replace(':' + key, tokens[key]);
+  if (this.tickTokens) for (var key in this.tickTokens) str = str.replace(':' + key, this.tickTokens[key]);
 
   if (this.lastDraw !== str) {
     this.stream.clearLine();

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -21,6 +21,7 @@ exports = module.exports = ProgressBar;
  *   - `stream` the output stream defaulting to stderr
  *   - `complete` completion character defaulting to "="
  *   - `incomplete` incomplete character defaulting to "-"
+ *   - `renderThrottle` minimum time between updates in milliseconds defaulting to 16
  *   - `callback` optional function to call when the progress bar completes
  *   - `clear` will clear the progress bar upon termination
  *

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -62,7 +62,7 @@ function ProgressBar(fmt, options) {
   };
   this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 16) : 0;
   this.callback = options.callback || function () {};
-  this.tickTokens = {};
+  this.tokens = {};
   this.lastDraw = '';
 }
 
@@ -80,7 +80,7 @@ ProgressBar.prototype.tick = function(len, tokens){
 
   // swap tokens
   if ('object' == typeof len) tokens = len, len = 1;
-  if (tokens) this.tickTokens = tokens;
+  if (tokens) this.tokens = tokens;
 
   // start time for eta
   if (0 == this.curr) this.start = new Date;
@@ -114,7 +114,7 @@ ProgressBar.prototype.render = function (tokens) {
   clearTimeout(this.renderThrottleTimeout);
   this.renderThrottleTimeout = null;
 
-  if (tokens) this.tickTokens = tokens;
+  if (tokens) this.tokens = tokens;
 
   if (!this.stream.isTTY) return;
 
@@ -148,7 +148,7 @@ ProgressBar.prototype.render = function (tokens) {
   str = str.replace(':bar', complete + incomplete);
 
   /* replace the extra tokens */
-  if (this.tickTokens) for (var key in this.tickTokens) str = str.replace(':' + key, this.tickTokens[key]);
+  if (this.tokens) for (var key in this.tokens) str = str.replace(':' + key, this.tokens[key]);
 
   if (this.lastDraw !== str) {
     this.stream.clearLine();

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -60,7 +60,7 @@ function ProgressBar(fmt, options) {
     complete   : options.complete || '=',
     incomplete : options.incomplete || '-'
   };
-  this.renderDelay = options.renderDelay === undefined ? 50 : options.renderDelay;
+  this.renderThrottle = options.renderThrottle !== 0 ? (options.renderThrottle || 50) : 0;
   this.callback = options.callback || function () {};
   this.tickTokens = {};
   this.lastDraw = '';
@@ -88,13 +88,13 @@ ProgressBar.prototype.tick = function(len, tokens){
   this.curr += len
 
   // schedule render
-  if (!this.renderTimeout) {
-    this.renderTimeout = setTimeout(this.render.bind(this), this.renderDelay);
+  if (!this.renderThrottleTimeout) {
+    this.renderThrottleTimeout = setTimeout(this.render.bind(this), this.renderThrottle);
   }
 
   // progress complete
   if (this.curr >= this.total) {
-    if (this.renderTimeout) this.render();
+    if (this.renderThrottleTimeout) this.render();
     this.complete = true;
     this.terminate();
     this.callback(this);
@@ -111,8 +111,8 @@ ProgressBar.prototype.tick = function(len, tokens){
  */
 
 ProgressBar.prototype.render = function (tokens) {
-  clearTimeout(this.renderTimeout);
-  this.renderTimeout = null;
+  clearTimeout(this.renderThrottleTimeout);
+  this.renderThrottleTimeout = null;
 
   if (tokens) this.tickTokens = tokens;
 


### PR DESCRIPTION
This makes render calls asynchronous and limits updates to once every `renderDelay` milliseconds fixing an issue where rapidly updating the progress bar would result in visible flickering and a noticeable degradation in performance.