### PR TITLE
Don't clear whole line every time; instead, clear everything after end of line

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -152,9 +152,9 @@ ProgressBar.prototype.render = function (tokens) {
   if (this.tokens) for (var key in this.tokens) str = str.replace(':' + key, this.tokens[key]);
 
   if (this.lastDraw !== str) {
-    this.stream.clearLine();
     this.stream.cursorTo(0);
     this.stream.write(str);
+    this.stream.clearLine(1);
     this.lastDraw = str;
   }
 };


### PR DESCRIPTION
This makes the progress bar much less flickery on laggy or bursty connections over SSH, etc.