### PR TITLE
Add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,4 +18,5 @@
   , "main": "index"
   , "engines": { "node": ">=0.4.0" }
   , "repository": "git://github.com/visionmedia/node-progress"
+  , "license": "MIT"
 }


### PR DESCRIPTION
npm recently updated its guidelines on license metadata in package.json files. The new guidelines ask maintainers to use the SPDX standard’s license expression syntax to show how their work is licensed in a machine-readable way. You will get a warning if you don’t.

https://github.com/npm/npm/releases/tag/v2.10.0