### PR TITLE
Time Formatting

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -104,6 +104,25 @@ ProgressBar.prototype.tick = function(len, tokens){
 };
 
 /**
+ * Function to format a number of milliseconds as human-readable
+ *
+ * @param {int} ms
+ * @api private
+ */
+function formatMilliseconds( ms )
+{
+    pad = function( n )
+    {
+	return ( n < 10 ) ? ( "0" + n ) : n;
+    }
+    
+    var date = new Date( ms );
+    var m = date.getMinutes();
+    var s = date.getSeconds();
+    return m ? m + ":" + pad( s ) : (ms/1000).toFixed(1);
+}
+
+/**
  * Method to render the progress bar with optional `tokens` to place in the
  * progress bar's `fmt` field.
  *
@@ -131,9 +150,8 @@ ProgressBar.prototype.render = function (tokens) {
   var str = this.fmt
     .replace(':current', this.curr)
     .replace(':total', this.total)
-    .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
-    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
-      .toFixed(1))
+    .replace(':elapsed', isNaN(elapsed) ? '0.0' : formatMilliseconds(elapsed))
+    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : formatMilliseconds(eta) )
     .replace(':percent', percent.toFixed(0) + '%');
 
   /* compute the available space (non-zero) for the bar */


### PR DESCRIPTION
'eta' and 'elapsed' display MM:SS on durations over 1 minute
