### PR TITLE
Display ETA/elapsed time in hours, minutes and seconds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,9 +48,9 @@ These are tokens you can use in the format of your progress bar.
 - `:bar` the progress bar itself
 - `:current` current tick number
 - `:total` total ticks
-- `:elapsed` time elapsed in seconds
+- `:elapsed` time elapsed in hours, minutes and seconds
 - `:percent` completion percentage
-- `:eta` estimated completion time in seconds
+- `:eta` estimated completion time in hours, minutes and seconds
 - `:rate` rate of ticks per second
 
 ### Custom Tokens
@@ -97,7 +97,7 @@ req.on('response', function(res){
   var len = parseInt(res.headers['content-length'], 10);
 
   console.log();
-  var bar = new ProgressBar('  downloading [:bar] :rate/bps :percent :etas', {
+  var bar = new ProgressBar('  downloading [:bar] :rate/bps :percent :eta', {
     complete: '=',
     incomplete: ' ',
     width: 20,

--- a/examples/download.js
+++ b/examples/download.js
@@ -9,7 +9,7 @@ var ProgressBar = require('../');
 
 var contentLength = 128 * 1024;
 
-var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+var bar = new ProgressBar('  downloading [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 20

--- a/examples/exact.js
+++ b/examples/exact.js
@@ -8,7 +8,7 @@
 
 var ProgressBar = require('../');
 
-var bar = new ProgressBar('  progress [:bar] :percent :etas', {
+var bar = new ProgressBar('  progress [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 40

--- a/examples/formats.js
+++ b/examples/formats.js
@@ -64,7 +64,7 @@ function bar4() {
 }
 
 function bar5() {
-  var bar = new ProgressBar('  [:bar] :elapseds elapsed, eta :etas', {
+  var bar = new ProgressBar('  [:bar] :elapsed elapsed, eta :eta', {
       width: 8
     , total: 50
   });

--- a/examples/toolong.js
+++ b/examples/toolong.js
@@ -7,7 +7,7 @@ var ProgressBar = require('../');
 
 // simulated download, passing the chunk lengths to tick()
 
-var bar = new ProgressBar('  downloading [:bar] :percent :etas', {
+var bar = new ProgressBar('  downloading [:bar] :percent :eta', {
     complete: '='
   , incomplete: ' '
   , width: 1024     /* something longer than the terminal width */

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -32,9 +32,9 @@ exports = module.exports = ProgressBar;
  *   - `:bar` the progress bar itself
  *   - `:current` current tick number
  *   - `:total` total ticks
- *   - `:elapsed` time elapsed in seconds
+ *   - `:elapsed` time elapsed in hours, minutes and seconds
  *   - `:percent` completion percentage
- *   - `:eta` eta in seconds
+ *   - `:eta` eta in hours, minutes and seconds
  *   - `:rate` rate of ticks per second
  *
  * @param {string} fmt
@@ -109,6 +109,29 @@ ProgressBar.prototype.tick = function(len, tokens){
   }
 };
 
+function formatMilliseconds(milliseconds) {
+  var pad = function(num) {
+    if (num < 10) {
+      return "0" + num;
+    }
+    return num;
+  };
+  
+  var hours = Math.floor(milliseconds / (60 * 60 * 1000));
+  milliseconds %= 60 * 60 * 1000;
+	
+  var minutes = Math.floor(milliseconds / (60 * 1000));
+  milliseconds %= 60 * 1000;
+	
+  var seconds = Math.floor(milliseconds / 1000);
+  milliseconds %= 1000;
+  
+  if (hours > 0 || minutes > 0) {
+    return (hours > 0 ? hours + ":" : "") + pad(minutes) + ":" + pad(seconds);
+  }
+  return seconds + "." + Math.floor(milliseconds / 100) + "s";
+}
+
 /**
  * Method to render the progress bar with optional `tokens` to place in the
  * progress bar's `fmt` field.
@@ -138,9 +161,8 @@ ProgressBar.prototype.render = function (tokens) {
   var str = this.fmt
     .replace(':current', this.curr)
     .replace(':total', this.total)
-    .replace(':elapsed', isNaN(elapsed) ? '0.0' : (elapsed / 1000).toFixed(1))
-    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
-      .toFixed(1))
+    .replace(':elapsed', isNaN(elapsed) ? '0.0' : formatMilliseconds(elapsed))
+    .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : formatMilliseconds(eta))
     .replace(':percent', percent.toFixed(0) + '%')
     .replace(':rate', Math.round(rate));
 


### PR DESCRIPTION
Replaces the ETA/elapsed time seconds display with hours, minutes and seconds.

Examples:

0.2s
5.5s
1:23
8:20:01