### PR TITLE
Fix bar width when using ANSI styling

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -145,7 +145,8 @@ ProgressBar.prototype.render = function (tokens) {
     .replace(':rate', Math.round(rate));
 
   /* compute the available space (non-zero) for the bar */
-  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
+  var clean = str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+  var availableSpace = Math.max(0, this.stream.columns - clean.replace(':bar', '').length);
   if(availableSpace && process.platform === 'win32'){
     availableSpace = availableSpace - 1;
   }


### PR DESCRIPTION
This fixes the issue when using colors that the progress bar will usually be collapsed. It strips the ANSI styling when calculating the available space and works with the raw data being displayed.

The regex was taken from: https://github.com/chalk/ansi-regex/blob/master/index.js#L3 and seems to work well.