### PR TITLE
Allow decimals in rate display

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -142,7 +142,7 @@ ProgressBar.prototype.render = function (tokens) {
     .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
       .toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%')
-    .replace(':rate', Math.round(rate));
+    .replace(':rate', (rate > 0 && rate < 1) ? rate.toFixed(2) : Math.round(rate));
 
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);


### PR DESCRIPTION
Here is a small modification to display rate with decimals if it is between 0 and 1.