### PR TITLE
fix: Slice complete correctly

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -159,7 +159,7 @@ ProgressBar.prototype.render = function (tokens) {
 
   /* add head to the complete string */
   if(completeLength > 0)
-    complete = complete.slice(0, -1) + this.chars.head;
+    complete = complete.slice(0, -this.chars.complete.length) + this.chars.head;
 
   /* fill in the actual progress bar */
   str = str.replace(':bar', complete + incomplete);


### PR DESCRIPTION
In case of colored complete char, the slice was not correct resulting in messy output.

This is visible in the Kitty terminal. iTerm2 seems to be handling incorrect ANSI codes.

Before: 

![image](https://user-images.githubusercontent.com/465582/45359794-ec2b8b80-b5cd-11e8-9420-3994b892b0af.png)

After:

![image](https://user-images.githubusercontent.com/465582/45359806-f6e62080-b5cd-11e8-87a3-7ff8c56e638e.png)

Test code : 
```js
var Progress = require('progress');
var chalk = require('chalk')

const colors = {
  blue: chalk.hex('#297EF2'),
  bgBlue: chalk.bgHex('#297EF2'),
  bgWhite: chalk.bgWhite
}

const template = [
  ':bar',
  ':percent',
  ':msg'
].join(' ')

const bar = new Progress(
  // message template
  template,
  // progress bar options
  {
    complete: colors.bgBlue(' '),
    incomplete: colors.bgWhite(' '),
    width: 2000, // exceed length is handled
    total: 10,
    clear: false
  }
)

const timer = setInterval(() => {
  bar.tick()
  if (bar.complete) {
    clearInterval(timer)
  }
}, 100)
```

