### PR TITLE
Account for size of token replacements when sizing the bar

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -69,6 +69,7 @@ function ProgressBar(fmt, options) {
   this.lastRender = -Infinity;
   this.callback = options.callback || function () {};
   this.tokens = {};
+  this.spaceRequiredForTokens = 0;
   this.lastDraw = '';
 }
 
@@ -147,8 +148,21 @@ ProgressBar.prototype.render = function (tokens, force) {
     .replace(':percent', percent.toFixed(0) + '%')
     .replace(':rate', Math.round(rate));
 
+  /* account for the replacement of the extra tokens */
+  var spaceRequiredForTokens = 0;
+  if (this.tokens) for (var key in this.tokens) {
+    if(this.tokens[key].length > key.length+1) {
+      spaceRequiredForTokens += this.tokens[key].length - (key.length+1)
+    }
+  };
+  if(spaceRequiredForTokens > this.spaceRequiredForTokens) {
+    this.spaceRequiredForTokens = spaceRequiredForTokens;
+  } else {
+    spaceRequiredForTokens = this.spaceRequiredForTokens;
+  }
+
   /* compute the available space (non-zero) for the bar */
-  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
+  var availableSpace = Math.max(0, this.stream.columns - spaceRequiredForTokens - str.replace(':bar', '').length);
   if(availableSpace && process.platform === 'win32'){
     availableSpace = availableSpace - 1;
   }

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -151,10 +151,11 @@ ProgressBar.prototype.render = function (tokens, force) {
   /* account for the replacement of the extra tokens */
   var spaceRequiredForTokens = 0;
   if (this.tokens) for (var key in this.tokens) {
-    if(this.tokens[key].length > key.length+1) {
-      spaceRequiredForTokens += this.tokens[key].length - (key.length+1)
-    }
+    if(str.indexOf(":"+key) == -1) continue;
+    spaceRequiredForTokens += this.tokens[key].length - (key.length+1)
   };
+
+  /* ensure spaceRequiredForTokens is at least 0, and is consistent accross ticks */
   if(spaceRequiredForTokens > this.spaceRequiredForTokens) {
     this.spaceRequiredForTokens = spaceRequiredForTokens;
   } else {


### PR DESCRIPTION
If we are not doing this, then the bar can overflow to the next line, then it starts drawing itself over and over again, because the start of the line is not the real start of the line but the start of the wrapped line, and that is really annoying...

Since we want the bar size to remain stable, the maximum size for a token is remembered.