### PR TITLE
Added a `humanFriendlyRate` option to show the download rate in KiB/s format instead of b/s.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,7 +103,7 @@ req.on('response', function(res){
     incomplete: ' ',
     width: 20,
     total: len,
-    humanFriendlyRate" true
+    humanFriendlyRate: true
   });
 
   res.on('data', function (chunk) {

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ These are keys in the options object you can pass to the progress bar along with
 - `renderThrottle` minimum time between updates in milliseconds defaulting to 16
 - `clear` option to clear the bar on completion defaulting to false
 - `callback` optional function to call when the progress bar completes
+- `humanFriendlyRate` will show download rate in KB/s insteaf of B/s.
 
 ### Tokens
 
@@ -97,11 +98,12 @@ req.on('response', function(res){
   var len = parseInt(res.headers['content-length'], 10);
 
   console.log();
-  var bar = new ProgressBar('  downloading [:bar] :rate/bps :percent :etas', {
+  var bar = new ProgressBar('  downloading [:bar] :rate :percent :etas', {
     complete: '=',
     incomplete: ' ',
     width: 20,
-    total: len
+    total: len,
+    humanFriendlyRate" true
   });
 
   res.on('data', function (chunk) {

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -26,6 +26,7 @@ exports = module.exports = ProgressBar;
  *   - `renderThrottle` minimum time between updates in milliseconds defaulting to 16
  *   - `callback` optional function to call when the progress bar completes
  *   - `clear` will clear the progress bar upon termination
+ *   - `humanFriendlyRate` will show download rate in KB/s insteaf of B/s.
  *
  * Tokens:
  *
@@ -70,6 +71,7 @@ function ProgressBar(fmt, options) {
   this.callback = options.callback || function () {};
   this.tokens = {};
   this.lastDraw = '';
+  this.humanFriendlyRate = options.humanFriendlyRate || false;
 }
 
 /**
@@ -145,7 +147,7 @@ ProgressBar.prototype.render = function (tokens, force) {
     .replace(':eta', (isNaN(eta) || !isFinite(eta)) ? '0.0' : (eta / 1000)
       .toFixed(1))
     .replace(':percent', percent.toFixed(0) + '%')
-    .replace(':rate', Math.round(rate));
+    .replace(':rate', (this.humanFriendlyRate ? (Math.round(rate) / 1024).toFixed(1) + 'KiB/s' : Math.round(rate) + 'B/s'  ));
 
   /* compute the available space (non-zero) for the bar */
   var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);


### PR DESCRIPTION
Showing download rate in `bps` is not the best way, so I added a `humanFriendlyRate` option to show the download rate in KiB/s. Also updated the README and the sample code.