### PR TITLE
Bug fix: Available space count on multi-line format mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.sock
 npm-debug.log
 yarn.lock
+.idea

--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -148,7 +148,7 @@ ProgressBar.prototype.render = function (tokens, force) {
     .replace(':rate', Math.round(rate));
 
   /* compute the available space (non-zero) for the bar */
-  var availableSpace = Math.max(0, this.stream.columns - str.replace(':bar', '').length);
+  var availableSpace = Math.max(0, ...str.replace(':bar', '').split('\n').map(line => this.stream.columns - line.length));
   if(availableSpace && process.platform === 'win32'){
     availableSpace = availableSpace - 1;
   }


### PR DESCRIPTION
Whenever the format argument is a string that has multiple lines, the script will calculate an incorrect number of available spaces by ignoring `\n` symbols.

This pull request will fix that issue.