### PR TITLE
Fixed NaN `:rate` and 0.0 `:eta` when `curr` is set.

### DIFF
--- a/lib/node-progress.js
+++ b/lib/node-progress.js
@@ -89,7 +89,7 @@ ProgressBar.prototype.tick = function(len, tokens){
   if (tokens) this.tokens = tokens;
 
   // start time for eta
-  if (0 == this.curr) this.start = new Date;
+  if (!this.start) this.start = new Date;
 
   this.curr += len
 


### PR DESCRIPTION
- Setting the current progress index to anything other than `0` will cause the value of `this.start` to be undefined. This causes the calculation for `:eta` and `:rate` to produce useless information.
    - Replaced conditional to set `start` only when the progress is ticked when `current` == 0.
    - We will always set the `start` time on first tick anyway. 
 
This PR should resolve and close #159 